### PR TITLE
Expose common window interface on container

### DIFF
--- a/lib/dodo/container.rb
+++ b/lib/dodo/container.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dodo/happening'
 require 'dodo/window'
 require 'algorithms'
@@ -18,13 +20,22 @@ module Dodo
       self
     end
 
-    def also(after:, over:, &block)
-      window = Dodo::Window.new over, &block
-      self << OffsetHappening.new(window, after)
+    def over(duration, after: 0, &block)
+      use Dodo::Window.new(duration, &block), after: after
     end
 
-    def also_use(window, after:)
-      self << OffsetHappening.new(window, after)
+    def also(over: duration, after: 0, &block)
+      over(over, after: after, &block)
+    end
+
+    def use(*windows, after: 0)
+      windows.each { |window| self << OffsetHappening.new(window, after) }
+      self
+    end
+
+    def repeat(times:, over:, after: 0, &block)
+      times.times { over(over, after: after, &block) }
+      self
     end
 
     def crammed(*)

--- a/lib/dodo/window.rb
+++ b/lib/dodo/window.rb
@@ -117,7 +117,7 @@ module Dodo
       Moment.new(&block).tap { |moment| self << moment }
     end
 
-    def repeat(times:, over: unused_duration, &block)
+    def repeat(times:, over:, &block)
       repeated_block = proc { times.times { instance_eval(&block) } }
       over(over, &repeated_block)
     end

--- a/lib/dodo/window.rb
+++ b/lib/dodo/window.rb
@@ -122,9 +122,9 @@ module Dodo
       over(over, &repeated_block)
     end
 
-    def simultaneously(over:, &block)
+    def simultaneously(&block)
       Container.new.tap do |container|
-        container.also(after: 0, over: over, &block)
+        container.instance_eval(&block)
         self << container
       end
     end
@@ -148,7 +148,10 @@ module Dodo
       end
     end
 
-    alias use <<
+    def use(*happenings)
+      happenings.each { |happening| self << happening }
+      self
+    end
   end
 
   class DodoException < StandardError

--- a/spec/dodo_end_2_end_spec.rb
+++ b/spec/dodo_end_2_end_spec.rb
@@ -56,24 +56,27 @@ RSpec.describe 'End to end' do
 
   let(:window) do
     Dodo.over 1.week do
-      simultaneously over: 1.day do
-        repeat times: 5 do
-          please do
-            name = Faker::Name.name
-            author = Author.new(name)
-            authors << author
-            users_and_authors << author
+      simultaneously do
+        over 1.day do
+          repeat times: 5, over: 1.day do
+            please do
+              name = Faker::Name.name
+              author = Author.new(name)
+              authors << author
+              users_and_authors << author
+            end
           end
         end
-      end.also over: 1.day, after: 2.hours do
 
-        repeat times: 10 do
-          please do
-            name = Faker::Name.name
-            email = Faker::Internet.safe_email(name)
-            user = User.new(name, email)
-            users << user
-            users_and_authors << user
+        also over: 1.day, after: 2.hours do
+          repeat times: 10, over: 1.day do
+            please do
+              name = Faker::Name.name
+              email = Faker::Internet.safe_email(name)
+              user = User.new(name, email)
+              users << user
+              users_and_authors << user
+            end
           end
         end
       end

--- a/spec/dodo_window_spec.rb
+++ b/spec/dodo_window_spec.rb
@@ -161,14 +161,6 @@ RSpec.describe Dodo::Window do
         expect(subject.happenings.size).to be k
       end
     end
-
-    context 'without a provided :over param' do
-      before { params.delete :over }
-      it 'should invoke #over once with window.unused_duration as an arg' do
-        expect(window).to receive(:over).with(window.unused_duration).once
-        subject
-      end
-    end
   end
 
   describe '#scheduler' do


### PR DESCRIPTION
Conceptually speaking, a `Container` can be considered to be a parallel `Window`.  That is, it permits many of the same operations: adding an existing `Window`, defining a new `Window` etc. As such the methods exposed by container should match those exposed by `Window` as closely as possible.

Furthermore, it will make for a simpler, more consistent API to expose these Container methods directly when specifying parallel configuration from within a Window.  

Accordingly, these changes add new `Container#over`, `Container#use` (replacing `Container#also_use`) and `Container#repeat` methods.  These methods match the equivalent methods on the `Window` class with the exception that they permit an `after` parameter.  This can be used to stagger any parallel timelines added to the `Container` (i.e. so that they don't start at the same time.)

They also update the Window#simultaneously method to accept a block whose contents will be evaluated within the context of a newly created Container object before being appended to the Window.  This makes for a far simpler, more consisted API.