### PR TITLE
Refactor the progress classes to make them less confusing

### DIFF
--- a/lib/dodo/runner.rb
+++ b/lib/dodo/runner.rb
@@ -35,13 +35,13 @@ module Dodo # :nodoc:
 
   def self.run(
     window, starting:, context: Context.new,
-    progress: ProgressLogger.new(Logger.new(STDOUT)), **opts
+    progress_factory: ProgressLogger.factory, **opts
   )
     distribution = Distribution.new starting
     scheduler = window.scheduler(distribution, context, opts)
+    progress = progress_factory.call total: scheduler.count
     scheduler = ProgressDecorator.new scheduler, progress
-    runner = Runner.new scheduler, opts
-    runner.call
+    Runner.new(scheduler, opts).call
   end
 
   class Context # :nodoc:
@@ -67,6 +67,8 @@ module Dodo # :nodoc:
       super
     end
 
+    # :reek:BooleanParameter
+    # Inherits interface from Object#respond_to_missing?
     def respond_to_missing?(symbol, respond_to_private = false)
       return true if assignment? symbol
 
@@ -77,6 +79,7 @@ module Dodo # :nodoc:
     end
 
     # :reek:NilCheck
+    # String#match? Unavailable for Ruby 2.3
     def assignment?(symbol)
       !symbol.to_s.match(/\w+=/).nil?
     end

--- a/spec/dodo_end_2_end_spec.rb
+++ b/spec/dodo_end_2_end_spec.rb
@@ -103,12 +103,15 @@ RSpec.describe 'End to end' do
   end
 
   let(:logger) { Logger.new STDOUT }
-  let(:progress) { Dodo::ProgressBar.new }
+  let(:progress_factory) { Dodo::ProgressBar.factory }
   let(:stretch) { 1 }
   let(:opts) { { stretch: stretch } }
   let(:distribution) { Dodo::Distribution.new 3.weeks.ago }
   let(:scheduler) { window.scheduler(distribution, context, opts) }
-  let(:decorated_enum) { Dodo::ProgressDecorator.new scheduler, progress }
+  let(:progress) { progress_factory.call }
+  let(:decorated_enum) do
+    Dodo::ProgressDecorator.new scheduler, progress
+  end
 
   let(:users_and_authors) { context.users_and_authors }
   let(:authors) { context.authors }
@@ -120,7 +123,7 @@ RSpec.describe 'End to end' do
   subject! do
     Dodo.run window, starting: 3.weeks.ago,
                      context: context,
-                     progress: progress, **opts
+                     progress_factory: progress_factory, **opts
   end
 
   context 'without scaling' do

--- a/spec/dodo_progress_spec.rb
+++ b/spec/dodo_progress_spec.rb
@@ -22,21 +22,46 @@ RSpec.describe Dodo::ProgressLogger do
     end
   end
 
-  describe '#current=' do
-    subject { progress.current = current }
+  describe '#increment' do
+    let(:increment) { 2 }
+    let(:incremented) { current + increment }
+
+    subject { progress.increment increment }
+
+    before do
+      progress.instance_variable_set :@current, current
+    end
+
+    it 'should add the value of increment to @current' do
+      subject
+      expect(progress.current).to eq(incremented)
+    end
+
+    it 'should return the incremented value' do
+      subject
+      expect(progress.current).to eq(incremented)
+    end
+
+    it 'should invoke on_increment' do
+      expect(progress).to receive(:on_increment).with(increment)
+      subject
+    end
+
     it 'should log the current progress as a fraction of the total' do
-      expect(logger).to receive(:info).with("#{prefix} #{current} / #{total}")
+      expect(logger).to receive(:info).with(
+        "#{prefix} #{incremented} / #{total}"
+      )
       subject
     end
 
     it 'should update the value of @current' do
       subject
-      expect(progress.current).to eq current
+      expect(progress.current).to eq current + increment
     end
-    context ' without an integer total' do
+    context 'without an integer total' do
       let(:progress) { Dodo::ProgressLogger.new logger, prefix: prefix }
       it 'should log the current progress by itself' do
-        expect(logger).to receive(:info).with("#{prefix} #{current}")
+        expect(logger).to receive(:info).with("#{prefix} #{incremented} / -")
         subject
       end
     end
@@ -45,30 +70,10 @@ RSpec.describe Dodo::ProgressLogger do
       it 'should log the current progress with the default prefix' do
         expect(logger).to receive(:info).with(
           "Dodo::ProgressLogger{#{progress.object_id}} : " \
-          "Progress Made : #{current} / #{total}"
+          "Progress Made : #{incremented} / #{total}"
         )
         subject
       end
-    end
-  end
-
-  describe '#+' do
-    let(:increment) { 2 }
-
-    subject { progress + increment }
-
-    before do
-      progress.current = current
-    end
-
-    it 'should add the value of increment to @current' do
-      subject
-      expect(progress.current).to eq(current + increment)
-    end
-
-    it 'should return the incremented value' do
-      subject
-      expect(progress.current).to eq(current + increment)
     end
   end
 end

--- a/spec/dodo_runner_spec.rb
+++ b/spec/dodo_runner_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dodo::Runner do
   let(:progress) do
     double.tap do |progress|
       allow(progress).to receive(:total=)
-      allow(progress).to receive(:+).and_return(progress)
+      allow(progress).to receive(:increment).and_return(progress)
     end
   end
   let(:opts) { { live: live, daemonise: daemonise, progress: progress } }
@@ -90,7 +90,7 @@ RSpec.describe Dodo::Runner do
         subject
       end
       it 'should update the progress each time it calls a moment' do
-        expect(progress).to receive(:+).exactly(moments.size).times
+        expect(progress).to receive(:increment).exactly(moments.size).times
         subject
       end
       context 'with daemonize = false' do


### PR DESCRIPTION
The `ProgressCounter` module makes use of `current=` and `+` methods which behave in a slightly surprising way.  Rename and combine these methods in order to make them more descriptive.  Also include a ProgressCounter::Unknown 'null' object to encapsulate logic pertaining to a missing progress total (I expect this may neem extending soon).

Finally, provide a `factory` method on the `ProgressCounter` singleton class that will be used to create a callable that can be used to create a `ProgressCounter` object at a later point.  This way we can keep progress totals immutable (we would never want this to change) and avoid exposing the total= method.