### PR TITLE
Refactor distributions again

### DIFF
--- a/lib/dodo/container.rb
+++ b/lib/dodo/container.rb
@@ -34,6 +34,11 @@ module Dodo
       ContainerScheduler.new self, starting_offset, context, opts
     end
 
+    # :reek:FeatureEnvy:
+    # Any method to resolve this smell would have to be included on the
+    # :HappeningOffset: class which would overload it somewhat.  It may be
+    # worth creating a separate decorator for these offset :Window: objects
+    # within :Container:s rather than recycling the existing :OffsetHappening:.
     def window_schedulers(starting_offset, context, opts)
       windows.map do |window|
         window.scheduler(starting_offset + window.offset, context, opts)

--- a/lib/dodo/container.rb
+++ b/lib/dodo/container.rb
@@ -45,25 +45,19 @@ module Dodo
     end
   end
 
-  class ContainerScheduler # :nodoc:
-    include Enumerable
-
-    def initialize(container, distribution, context, opts = {})
-      @container = container
-      @starting_offset = distribution.next
-      @context = context
+  class ContainerScheduler < Scheduler # :nodoc:
+    def initialize(container, starting_offset, context, opts = {})
+      super
       @moment_heap = Containers::MinHeap.new []
       @window_schedulers = container.windows.map do |window|
         window.scheduler(
-          [@starting_offset + window.offset].to_enum, @context, opts
-        ).each
+          @starting_offset + window.offset, @context, opts
+        ).to_enum :each
       end
       @window_schedulers.each { |scheduler| push_moment_from_enum scheduler }
     end
 
     def each
-      return to_enum(:each) unless block_given?
-
       until @moment_heap.empty?
         moment = @moment_heap.next_key
         scheduler = @moment_heap.pop

--- a/lib/dodo/container.rb
+++ b/lib/dodo/container.rb
@@ -56,7 +56,7 @@ module Dodo
       super
       @moment_heap = Containers::MinHeap.new []
       @window_schedulers = container.window_schedulers(
-        @starting_offset, @context, opts
+        starting_offset, context, opts
       ).map(&:to_enum)
       @window_schedulers.each(&method(:push_moment_from_enum))
     end

--- a/lib/dodo/happening.rb
+++ b/lib/dodo/happening.rb
@@ -45,4 +45,15 @@ module Dodo
       Timecop.freeze(offset) { yield }
     end
   end
+
+  class Scheduler # :nodoc:
+    include Enumerable
+
+    def initialize(happening, starting_offset, context, opts = {})
+      @happening = happening
+      @starting_offset = starting_offset
+      @context = context
+      @opts = opts
+    end
+  end
 end

--- a/lib/dodo/happening.rb
+++ b/lib/dodo/happening.rb
@@ -55,5 +55,9 @@ module Dodo
       @context = context
       @opts = opts
     end
+
+    private
+
+    attr_reader :happening, :starting_offset, :context, :opts
   end
 end

--- a/lib/dodo/moment.rb
+++ b/lib/dodo/moment.rb
@@ -18,20 +18,9 @@ module Dodo
     end
   end
 
-  class MomentScheduler # :nodoc:
-    include Enumerable
-
-    def initialize(moment, distribution, context, opts = {})
-      @moment = moment
-      @distribution = distribution
-      @context = context
-      @opts = opts
-    end
-
+  class MomentScheduler < Scheduler # :nodoc:
     def each
-      return to_enum(:each) unless block_given?
-
-      yield ContextualMoment.new(@moment, @distribution.next, @context)
+      yield ContextualMoment.new(@happening, @starting_offset, @context)
     end
   end
 end

--- a/lib/dodo/moment.rb
+++ b/lib/dodo/moment.rb
@@ -20,7 +20,7 @@ module Dodo
 
   class MomentScheduler < Scheduler # :nodoc:
     def each
-      yield ContextualMoment.new(@happening, @starting_offset, @context)
+      yield ContextualMoment.new(happening, starting_offset, context)
     end
   end
 end

--- a/lib/dodo/runner.rb
+++ b/lib/dodo/runner.rb
@@ -37,8 +37,7 @@ module Dodo # :nodoc:
     window, starting:, context: Context.new,
     progress_factory: ProgressLogger.factory, **opts
   )
-    distribution = Distribution.new starting
-    scheduler = window.scheduler(distribution, context, opts)
+    scheduler = window.scheduler(starting, context, opts)
     progress = progress_factory.call total: scheduler.count
     scheduler = ProgressDecorator.new scheduler, progress
     Runner.new(scheduler, opts).call

--- a/lib/dodo/window.rb
+++ b/lib/dodo/window.rb
@@ -165,6 +165,8 @@ module Dodo # :nodoc:
       @distribution = Distribution.new starting_offset, window, opts
     end
 
+    # :reek:NestedIterators:
+    # Not sure how this can be avoided nicely at the moment
     def each
       @distribution.each do |happening, offset|
         happening.scheduler(offset, context, opts).each do |moment|

--- a/lib/dodo/window.rb
+++ b/lib/dodo/window.rb
@@ -162,12 +162,12 @@ module Dodo # :nodoc:
   class WindowScheduler < Scheduler # :nodoc:
     def initialize(window, starting_offset, parent_context, opts = {})
       super window, starting_offset, parent_context.push, opts
-      @distribution = Distribution.new @starting_offset, window, opts
+      @distribution = Distribution.new starting_offset, window, opts
     end
 
     def each
       @distribution.each do |happening, offset|
-        happening.scheduler(offset, @context, @opts).each do |moment|
+        happening.scheduler(offset, context, opts).each do |moment|
           yield moment
         end
       end

--- a/spec/dodo_moment_enumerator_spec.rb
+++ b/spec/dodo_moment_enumerator_spec.rb
@@ -3,18 +3,13 @@
 require 'rspec'
 RSpec.describe Dodo::MomentScheduler do
   let(:block) { -> { true } }
-  let(:distribution) { double }
+  let(:starting_offset) { rand 100 }
   let(:stretch) { 2 }
   let(:opts) { { stretch: stretch } }
   let(:moment) { Dodo::Moment.new(&block) }
   let(:context) { Dodo::Context.new }
   let(:scheduler) do
-    Dodo::MomentScheduler.new moment, distribution, context, opts
-  end
-  let(:dist_next) { rand 10 }
-
-  before do
-    allow(distribution).to receive(:next).and_return(dist_next)
+    Dodo::MomentScheduler.new moment, starting_offset, context, opts
   end
 
   describe '#initialize' do
@@ -26,12 +21,6 @@ RSpec.describe Dodo::MomentScheduler do
     end
   end
   describe '#each' do
-    context 'without a block' do
-      subject { scheduler.each }
-      it 'should return an Enumerator' do
-        expect(subject).to be_an Enumerator
-      end
-    end
     context 'with a block' do
       subject { scheduler }
       it 'should yield exactly once' do
@@ -42,9 +31,9 @@ RSpec.describe Dodo::MomentScheduler do
           have_attributes(__getobj__: moment)
         )
       end
-      it 'should offset these moments according to the distribution' do
+      it 'should offset the moment by the starting offset' do
         expect { |b| subject.each(&b) }.to yield_with_args(
-          have_attributes(offset: dist_next)
+          have_attributes(offset: starting_offset)
         )
       end
     end

--- a/spec/dodo_runner_spec.rb
+++ b/spec/dodo_runner_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Dodo::Runner do
   end
   let(:start) { 2.weeks.ago }
   let(:context) { Dodo::Context.new }
-  let(:distribution) { Dodo::Distribution.new start }
-  let(:scheduler) { window.scheduler(distribution, context) }
+  let(:starting_offset) { rand 100 }
+  let(:scheduler) { window.scheduler(starting_offset, context) }
   let(:decorated_enum) { Dodo::ProgressDecorator.new scheduler, progress }
   let(:runner) { described_class.new decorated_enum, opts }
 

--- a/spec/dodo_window_enumerator_spec.rb
+++ b/spec/dodo_window_enumerator_spec.rb
@@ -26,39 +26,16 @@ RSpec.describe Dodo::WindowScheduler do
   end
 
   let(:scale_opts) { {} }
+  let(:stretch) { scale_opts.fetch(:stretch) { 1 } }
 
   let(:starting_offset) { rand(10).days }
   let(:context) { Dodo::Context.new }
-  let(:parent_distribution) { [starting_offset].to_enum }
   let(:scheduler) do
-    described_class.new window, parent_distribution, context, scale_opts
+    described_class.new window, starting_offset, context, scale_opts
   end
 
   before do
     allow(SecureRandom).to receive(:random_number).and_return(*random_numbers)
-  end
-
-  describe '#stretch' do
-    subject { scheduler.stretch }
-    context 'without opts' do
-      it 'should have a default value of 1' do
-        expect(subject).to eq 1
-      end
-    end
-    context 'with a stretch param passed in the scale_opts hash' do
-      let(:stretch) { rand 7 + rand }
-      let(:scale_opts) { { stretch: stretch } }
-      it 'should return the value of the stretch opt' do
-        expect(subject).to eq stretch
-      end
-      context 'with a scale param passed in the scaled_opts hash' do
-        let(:scale) { rand 7 + rand }
-        let(:scale_opts) { { scale: scale, stretch: stretch } }
-        it 'should return the value of the scale opt' do
-          expect(subject).to eq scale
-        end
-      end
-    end
   end
 
   describe '#each' do
@@ -78,7 +55,7 @@ RSpec.describe Dodo::WindowScheduler do
         it 'should yield happenings within a range equal to that of the
             stretched duration' do
           expect(subject.last.offset - subject.first.offset).to eq(
-            (window.unused_duration - random_numbers[2]) * scheduler.stretch
+            (window.unused_duration - random_numbers[2]) * stretch
           )
         end
 
@@ -87,7 +64,7 @@ RSpec.describe Dodo::WindowScheduler do
           random_numbers[2..random_numbers.size].each_with_index do |rnd, index|
             expect(subject[index].offset).to eq(
               starting_offset +
-              (scheduler.stretch * (
+              (stretch * (
                 child_window.duration + child_container.duration + rnd
               ))
             )
@@ -107,13 +84,6 @@ RSpec.describe Dodo::WindowScheduler do
     context 'with a stretch parameter provided in scale_opts' do
       let(:stretch) { rand 2..5 }
       let(:scale_opts) { { stretch: stretch } }
-
-      it_behaves_like 'an scheduler of offset moments'
-    end
-
-    context 'with a scale parameter provided in scale_opts' do
-      let(:scale) { rand 2..5 }
-      let(:scale_opts) { { scale: scale } }
 
       it_behaves_like 'an scheduler of offset moments'
     end


### PR DESCRIPTION
The (uniform) `Distribution` classes were previously clumsy and manually implemented a lot of logic we could get for free using the `Enumerable` module.

This PR rectifies this (see commit messages for more details) and furthermore simplifies the various classes that make use of the `Distribution` class (and their tests)