### PR TITLE
 Expose addition and scalar multiplication and paralellisation operators on the Window class

### DIFF
--- a/lib/dodo/container.rb
+++ b/lib/dodo/container.rb
@@ -22,8 +22,9 @@ module Dodo
   class Container < Timeline # :nodoc:
     schedule_with ContainerScheduler
 
-    def initialize
+    def initialize(&block)
       super 0
+      instance_eval(&block) if block_given?
     end
 
     def over(duration, after: 0, &block)

--- a/lib/dodo/window.rb
+++ b/lib/dodo/window.rb
@@ -115,7 +115,7 @@ module Dodo # :nodoc:
       @parent = parent
       @total_child_duration = 0
       super duration
-      instance_eval(&block)
+      instance_eval(&block) if block_given?
     end
 
     def unused_duration
@@ -136,10 +136,7 @@ module Dodo # :nodoc:
     end
 
     def simultaneously(&block)
-      Container.new.tap do |container|
-        container.instance_eval(&block)
-        use container
-      end
+      use Container.new(&block)
     end
 
     def use(*timelines)

--- a/lib/dodo/window.rb
+++ b/lib/dodo/window.rb
@@ -144,6 +144,25 @@ module Dodo # :nodoc:
       self
     end
 
+    def +(other)
+      Window.new duration + other.duration do
+        use(*(to_a + other.to_a))
+      end
+    end
+
+    def *(other)
+      Window.new(duration * other) do
+        use(*Array.new(other) { entries }.reduce(:+))
+      end
+    end
+
+    def **(other)
+      this = self
+      Window.new(duration) do
+        simultaneously { use(*Array.new(other) { this }) }
+      end
+    end
+
     private
 
     def <<(timeline)

--- a/spec/dodo_container_spec.rb
+++ b/spec/dodo_container_spec.rb
@@ -14,9 +14,27 @@ RSpec.describe Dodo::Container do
   describe '#initialize' do
     subject { container }
 
-    context 'with a block defining a Dodo::Window' do
+    context 'without a block' do
       it 'should have an initial duration of 0' do
         expect(subject.duration).to eq 0
+      end
+    end
+
+    context 'with a block' do
+      let(:allocated) { Dodo::Container.allocate }
+      let(:block) { proc { true } }
+
+      subject { Dodo::Container.new(&block) }
+
+      it 'should have an initial duration of 0' do
+        expect(subject.duration).to eq 0
+      end
+
+      it 'should call instance_eval using the block passed' do
+        expect(allocated).to receive(:instance_eval) do |&blk|
+          expect(blk).to eq block
+        end
+        allocated.send :initialize, &block
       end
     end
   end

--- a/spec/dodo_window_spec.rb
+++ b/spec/dodo_window_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe Dodo::Window do
       end
       uninitialized.send(:initialize, duration, &block)
     end
+
+    context 'without a block provided' do
+      subject { Dodo::Window.new duration }
+      it 'should set duration' do
+        expect(subject.duration).to eq duration
+      end
+
+      it 'should initialize @timelines as an empty array' do
+        expect(subject.instance_variable_get(:@timelines)).to eq []
+      end
+
+      it 'should initialize @total_child_duration as 0' do
+        expect(subject.instance_variable_get(:@total_child_duration)).to eq 0
+      end
+    end
   end
 
   describe '#<<' do
@@ -194,11 +209,6 @@ RSpec.describe Dodo::Window do
 
     before do
       allow(Dodo::Container).to receive(:new).and_return container
-      Dodo::Container.send(:define_method, :called?) {}
-    end
-
-    after do
-      Dodo::Container.send :remove_method, :called?
     end
 
     it 'should append the container to the timeline array' do
@@ -208,18 +218,11 @@ RSpec.describe Dodo::Window do
     end
 
     it 'should evaluate the block passed' do
-      expect(container).to receive(:called?).with no_args
+      expect(Dodo::Container).to receive(:new) do |&blk|
+        expect(blk).to eq block
+        container
+      end
       subject
-    end
-
-    it 'should evaluate the block passed within the context of the created
-        container' do
-      expect(container).to receive(:instance_eval)
-      subject
-    end
-
-    it 'should return a new Container object' do
-      expect(subject).to eq container
     end
   end
 end

--- a/spec/dodo_window_spec.rb
+++ b/spec/dodo_window_spec.rb
@@ -225,4 +225,77 @@ RSpec.describe Dodo::Window do
       subject
     end
   end
+
+  describe '#+' do
+    let(:window) { build :window }
+    let(:another_window) { build :window }
+
+    subject { window + another_window }
+
+    it 'should return a window' do
+      expect(subject).to be_a Dodo::Window
+    end
+
+    it 'should return a new window whose duration is the sum of the
+        two original window' do
+      expect(subject.duration).to eq(
+        window.duration + another_window.duration
+      )
+    end
+
+    it 'should return a new window whose child window array is a
+        concatenation of the child window arrays of the two original
+        window' do
+      expect(subject.to_a).to eq(window.to_a + another_window.to_a)
+    end
+  end
+
+  describe '#*' do
+    let(:window) { build :window }
+    let(:factor) { rand 1..5 }
+
+    subject { window * factor }
+
+    it 'should return a window' do
+      expect(subject).to be_a Dodo::Window
+    end
+
+    it 'should return a new window whose duration is the product of the original
+        window\'s duration and the factor' do
+      expect(subject.duration).to eq(
+        window.duration * factor
+      )
+    end
+
+    it 'should return a new window whose child window array is that of the
+        original window concatenated with itself factor times' do
+      expect(subject.to_a).to eq(window.to_a * factor)
+    end
+  end
+
+  describe '#**' do
+    let(:window) { build :window }
+    let(:factor) { rand 5 }
+
+    subject { window**factor }
+
+    it 'should return a window' do
+      expect(subject).to be_a Dodo::Window
+    end
+
+    it 'should return a new window consisting of a single timeline' do
+      expect(subject.size).to eq 1
+    end
+
+    it 'should return a new window consisting of a single timeline' do
+      expect(subject.first).to be_a Dodo::Container
+    end
+
+    it 'should return a new window consisting of a single timeline which itself
+        consists of the original window parallelised factor times' do
+      expect(
+        subject.first.instance_variable_get(:@timelines).map(&:__getobj__)
+      ).to eq([window] * factor)
+    end
+  end
 end


### PR DESCRIPTION
each of these operators returns a new `Window` object. the addition (`+`) operator creates a new `Window` whose child timelines are the concatenation of the two original windows and whose duration is the sum of the durations of the two original windows.  The scalar multiplication operator performs repeated addition.  The "parallelisation operator" (tentatively (`**`) at the moment) creates a new window whose duration is that of the original window and that consists of a single container, parallelising the original window `n` times (where `n` is the integral argument passed to the operator).

The idea is that these operators can be used to create scalable timelines that can be used to generate datasets of varying size, as determined at runtime.

For example, consider a situation in which we wish to generate data corresponding to an organisation and then mock sales data belonging that organisation.  Suppose also that we wish to be able to generate datasets of different sizes.

Regardless of the size of the dataset we would only ever want one organisation with the size of the datasets then differing in the quantities of the sales data only.

In the code below, let `organisation_window` be a `Window` which could be used to create data pertaining to the organisation data itself while `sales_window` be a window to create individual sales item data.  Finally let `factor` denote some integral factor which we may want to scale by.  This could be provided as an argument in a rake task.

```ruby
scaled_window = organisation_window + (sales_window * factor)
```