### PR TITLE
Ensure Scope#respond_to? method behaves as expected

### DIFF
--- a/lib/dodo/scope.rb
+++ b/lib/dodo/scope.rb
@@ -5,6 +5,7 @@ module Dodo
     def initialize(scope, symbol)
       @scope = scope
       @symbol = symbol
+      @instance_var = :"@#{@symbol.to_s.chomp('=')}"
     end
 
     def access(*args)
@@ -22,21 +23,17 @@ module Dodo
     def get
       scope = @scope
       while scope
-        if scope.instance_variable_defined? instance_var
-          return scope.instance_variable_get instance_var
+        if scope.instance_variable_defined? @instance_var
+          return scope.instance_variable_get @instance_var
         end
 
         scope = scope.parent
       end
-      raise NoMethodError
+      raise NameError
     end
 
     def set(value)
-      @scope.instance_variable_set instance_var, value
-    end
-
-    def instance_var
-      :"@#{@symbol.to_s.chomp('=')}"
+      @scope.instance_variable_set @instance_var, value
     end
   end
 
@@ -57,7 +54,7 @@ module Dodo
 
     def method_missing(symbol, *args)
       Accessor.new(self, symbol).access(*args)
-    rescue NoMethodError
+    rescue NameError
       super
     end
 
@@ -69,7 +66,7 @@ module Dodo
 
       accessor.access
       true
-    rescue NoMethodError
+    rescue NameError
       super
     end
   end

--- a/spec/dodo_scope_spec.rb
+++ b/spec/dodo_scope_spec.rb
@@ -21,6 +21,34 @@ RSpec.describe Dodo::Scope do
     end
   end
 
+  describe '#respond_to?' do
+    let(:symbol) { :abc }
+    subject { scope.respond_to? symbol }
+
+    context 'where the symbol denotes a valid setter' do
+      context 'where the symbol denotes a valid setter' do
+        let(:symbol) { :abc= }
+        it 'should return true' do
+          expect(subject).to be true
+        end
+      end
+    end
+
+    context 'where the symbol is not valid' do
+      let(:symbol) { :abc? }
+      it 'should return false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'where symbol denotes a valid getter' do
+      before { scope.abc = true }
+      it 'should return true' do
+        expect(subject).to be true
+      end
+    end
+  end
+
   describe '#set' do
     subject { scope.foo = 'bar' }
 


### PR DESCRIPTION
The `Scope#response_to_missing?` method was not being covered in tests.  Furthermore, attempting to read send a message to a scope that was not a valid instance variable when prepended with a `@` (e.g. `:matches?`) resulted in `NameError`s.  This commit ensures attempts to send such messages are handled correctly by ensuring that their handling is deferred to the superclass of `Scope`