### PR TITLE
Explicity provide context when calling Moments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,30 @@ write _articles_ and _users_ _comment_ on these articles.
 We could use `Bonito` to define a `serial timeline`:
 
 ```ruby
+# First we create data structures to store out data and keep track of them in
+ # a `Scope` object: 
+Bonito::Scope.new.tap do |scope|
+  scope.authors = []
+  scope.articles = []
+  scope.users = []
+  scope.comments = []
+  scope.users_and_authors = []
+end
+
+# Next we define out serial timeline:
 serial = Bonito.over 1.week do
-  please do
-    author = authors.sample
+  please do |scope|
+    author = scope.authors.sample
     title = Faker::Company.bs
-    self.article = Article.new(title, author)
-    articles << article
+    scope.article = Article.new(title, author)
+    scope.articles << article
   end
 
   repeat times: rand(10), over: 5.days do
-    please do
-      user = users.sample
+    please do |scope|
+      user = scope.users.sample
       content = Faker::Lorem.sentence
-      comments << Comment.new(content, article, user)
+      scope.comments << Comment.new(content, scope.article, user)
     end
   end
 end

--- a/lib/bonito/timeline.rb
+++ b/lib/bonito/timeline.rb
@@ -67,7 +67,7 @@ module Bonito
     end
 
     def evaluate
-      freeze { @scope.instance_eval(&self) }
+      freeze { to_proc.call(@scope) }
     end
 
     private

--- a/spec/end_2_end_spec.rb
+++ b/spec/end_2_end_spec.rb
@@ -61,41 +61,41 @@ RSpec.describe 'End to end' do
       simultaneously do
         over 1.day do
           repeat times: 5, over: 1.day do
-            please do
+            please do |scope|
               name = Faker::Name.name
               author = Author.new(name)
-              authors << author
-              users_and_authors << author
+              scope.authors << author
+              scope.users_and_authors << author
             end
           end
         end
 
         also over: 1.day, after: 2.hours do
           repeat times: 10, over: 1.day do
-            please do
+            please do |scope|
               name = Faker::Name.name
               email = Faker::Internet.safe_email(name)
               user = User.new(name, email)
-              users << user
-              users_and_authors << user
+              scope.users << user
+              scope.users_and_authors << user
             end
           end
         end
       end
 
       repeat times: 5, over: 5.days do
-        please do
-          author = authors.sample
+        please do |scope|
+          author = scope.authors.sample
           title = Faker::Company.bs
-          self.article = Article.new(title, author)
-          articles << article
+          scope.article = Article.new(title, author)
+          scope.articles << scope.article
         end
 
         repeat times: rand(10), over: 5.hours do
-          please do
-            user = users.sample
+          please do |scope|
+            user = scope.users.sample
             content = Faker::Lorem.sentence
-            comments << Comment.new(content, article, user)
+            scope.comments << Comment.new(content, scope.article, user)
           end
         end
       end

--- a/spec/timeline_spec.rb
+++ b/spec/timeline_spec.rb
@@ -12,14 +12,12 @@ RSpec.describe Bonito::ScopedMoment do
     subject { scoped_moment.evaluate }
 
     it 'should evaluate the moment within the scope' do
-      expect(scope).to receive(:instance_eval) do |&block|
-        expect(block).to eq(moment.to_proc)
-      end
+      expect(moment.to_proc).to receive(:call).with(scope)
       subject
     end
 
     it 'should evaluate the moment within the scope at the offset' do
-      expect(scope).to receive(:instance_eval) do |&_block|
+      expect(moment.to_proc).to receive(:call) do |&_block|
         expect(Time.now).to eq offset
       end
       subject


### PR DESCRIPTION
Using `instance_eval` made things very confusing as the scope wasn't exposed to the user.  This made it hard to fathom what `self` referred to in these cases.

Before:

```ruby
please do
  self.articles << Article.new
  # I don't think it's immediately clear that `self.articles` here and ...
end

please do
  puts articles # <= `articles` here are the same object.
end
```

After:

```ruby
please do |scope|
  scope.articles << Article.new
end

please do |scope|
  puts scope.articles
end
```