### PR TITLE
CI: Add 2.7, 2.6 to matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: ruby
 rvm:
 - 2.5.1
 - 2.3.0
+- 2.6
+- 2.7
 before_install:
 - gem update --system
 - gem install bundler


### PR DESCRIPTION
The short names are taken from https://github.com/rvm/rvm/blob/master/config/known#L12 and rvm is used in Travis CI, so these names will expand to the numbers named in that configuration file.

I placed them last, so that the selected versions start the CI run.